### PR TITLE
Updated vending machine to keep cursor on previously selected item.

### DIFF
--- a/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
@@ -70,11 +70,20 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_VendingMachine::
 	message LilycoveCity_DepartmentStoreRooftop_Text_WhichDrinkWouldYouLike
 	waitmessage
 	showmoneybox 0, 0
+	setvar VAR_TEMP_3, 0
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink::
-	multichoice 16, 0, MULTI_VENDING_MACHINE, FALSE
+	switch VAR_TEMP_3
+	case 0, LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_FreshWater
+	case 1, LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_SodaPop
+	case 2, LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_Lemonade
+	goto LilycoveCity_DepartmentStoreRooftop_EventScript_ExitVendingMachine
+	end
+
+LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_FreshWater::
+	multichoicedefault 16, 0, MULTI_VENDING_MACHINE, 0, FALSE
 	copyvar VAR_TEMP_1, VAR_RESULT
 	switch VAR_TEMP_1
 	case 0, LilycoveCity_DepartmentStoreRooftop_EventScript_FreshWater
@@ -84,18 +93,41 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink::
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_ExitVendingMachine
 	end
 
+LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_SodaPop::
+	multichoicedefault 16, 0, MULTI_VENDING_MACHINE, 1, FALSE
+	copyvar VAR_TEMP_1, VAR_RESULT
+	switch VAR_TEMP_1
+	case 0, LilycoveCity_DepartmentStoreRooftop_EventScript_FreshWater
+	case 1, LilycoveCity_DepartmentStoreRooftop_EventScript_SodaPop
+	case 2, LilycoveCity_DepartmentStoreRooftop_EventScript_Lemonade
+	goto LilycoveCity_DepartmentStoreRooftop_EventScript_ExitVendingMachine
+	end
+
+LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseDrink_Lemonade::
+	multichoicedefault 16, 0, MULTI_VENDING_MACHINE, 2, FALSE
+	copyvar VAR_TEMP_1, VAR_RESULT
+	switch VAR_TEMP_1
+	case 0, LilycoveCity_DepartmentStoreRooftop_EventScript_FreshWater
+	case 1, LilycoveCity_DepartmentStoreRooftop_EventScript_SodaPop
+	case 2, LilycoveCity_DepartmentStoreRooftop_EventScript_Lemonade
+	goto LilycoveCity_DepartmentStoreRooftop_EventScript_ExitVendingMachine
+	end
+
 LilycoveCity_DepartmentStoreRooftop_EventScript_FreshWater::
 	setvar VAR_TEMP_2, ITEM_FRESH_WATER
+	setvar VAR_TEMP_3, 0
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_TryBuyDrink
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_SodaPop::
 	setvar VAR_TEMP_2, ITEM_SODA_POP
+	setvar VAR_TEMP_3, 1
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_TryBuyDrink
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_Lemonade::
 	setvar VAR_TEMP_2, ITEM_LEMONADE
+	setvar VAR_TEMP_3, 2
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_TryBuyDrink
 	end
 
@@ -141,7 +173,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_TryBuyDrink::
 	bufferitemname STR_VAR_2, VAR_TEMP_2
 	bufferstdstring STR_VAR_3, STDSTRING_ITEMS
 	msgbox gText_PutItemInPocket, MSGBOX_DEFAULT
-	random 64  @ 1/64 chance of an additional drink dropping
+	random 16  @ 1/16 chance of an additional drink dropping
 	goto_if_ne VAR_RESULT, 0, LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseNewDrink
 	checkitemspace VAR_TEMP_2
 	goto_if_eq VAR_RESULT, FALSE, LilycoveCity_DepartmentStoreRooftop_EventScript_NoRoomForDrink
@@ -151,7 +183,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_TryBuyDrink::
 	bufferitemname STR_VAR_2, VAR_TEMP_2
 	bufferstdstring STR_VAR_3, STDSTRING_ITEMS
 	msgbox gText_PutItemInPocket, MSGBOX_DEFAULT
-	random 64  @ 1/64 * the prev 1/64 chance of a third additional drink dropping, ~ 0.02% chance
+	random 32  @ 1/32 * the prev 1/16 chance of a third additional drink dropping,
 	goto_if_ne VAR_RESULT, 0, LilycoveCity_DepartmentStoreRooftop_EventScript_ChooseNewDrink
 	checkitemspace VAR_TEMP_2
 	goto_if_eq VAR_RESULT, 0, LilycoveCity_DepartmentStoreRooftop_EventScript_NoRoomForDrink


### PR DESCRIPTION
Updated vending machine to keep cursor on previously selected item andd increase chance of free cans dropping.

Just a small QoL update for vending machine drink purchases, feel free to revert the second and third drink chances back to 1/64 each if preferred.