### PR TITLE
Fixed EV items when using NO PLAYER EVs

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4517,6 +4517,13 @@ static bool8 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, u16 item)
     return TRUE;
 }
 
+static bool8 EV_Item_With_EVs_Disabled(u16 item)
+{
+    if (GetItemEffectType(item) == ITEM_EFFECT_HP_EV || ITEM_EFFECT_ATK_EV || ITEM_EFFECT_SPATK_EV || ITEM_EFFECT_SPDEF_EV || ITEM_EFFECT_SPEED_EV || ITEM_EFFECT_DEF_EV)
+        return FALSE;
+    return TRUE;
+}
+
 static bool8 IsItemFlute(u16 item)
 {
     if (item == ITEM_BLUE_FLUTE || item == ITEM_RED_FLUTE || item == ITEM_YELLOW_FLUTE)
@@ -4540,6 +4547,11 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
     bool8 canHeal, cannotUse;
 
     if (NotUsingHPEVItemOnShedinja(mon, item) == FALSE)
+    {
+        cannotUse = TRUE;
+    }
+    else if ((EV_Item_With_EVs_Disabled(item) == FALSE) && (gSaveBlock1Ptr->tx_Challenges_NoEVs == 1))
+    //Disable the use of EV items with the challenge NO EVs.
     {
         cannotUse = TRUE;
     }


### PR DESCRIPTION
Fixes the usage of EV items (Vitamin, Calcium, etc.) when using the "Player EVs" option set to "No".