### PR TITLE
Changed the volume of SE_SELECT from 63% to 47%

### DIFF
--- a/songs.mk
+++ b/songs.mk
@@ -1072,7 +1072,7 @@ $(MID_SUBDIR)/se_success.s: %.s: %.mid
 	$(MID) $< $@ -E -G127 -V080 -P4
 
 $(MID_SUBDIR)/se_select.s: %.s: %.mid
-	$(MID) $< $@ -E -G127 -V080 -P5
+	$(MID) $< $@ -E -G127 -V060 -P5
 
 $(MID_SUBDIR)/se_ball_trade.s: %.s: %.mid
 	$(MID) $< $@ -E -G127 -V100 -P5


### PR DESCRIPTION
Changed the volume of SE_SELECT from 63% to 47%, V060/V128 (The minimum "hg_" sound effect/music I found was @ 40%. That was the Lighthouse & the Bug Catching contest prep music was a little higher than that)

I'd ask for you to try the change for yourself and adjust for what you feel is best. I had to `make clean` and then rebuild for the change to take effect