### PR TITLE
Nature Mints and Synchronize Fix

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -415,7 +415,7 @@ static u8 PickWildMonNature(void)
         && GetMonAbility(&gPlayerParty[0]) == ABILITY_SYNCHRONIZE
         && Random() % 2 == 0)
         {
-            return GetMonData(&gPlayerParty[0], MON_DATA_PERSONALITY) % NUM_NATURES;
+            return GetNature(&gPlayerParty[0], TRUE);
         }
     }
     else if (gSaveBlock1Ptr->tx_Mode_Synchronize == 1)
@@ -423,7 +423,7 @@ static u8 PickWildMonNature(void)
         if (!GetMonData(&gPlayerParty[0], MON_DATA_SANITY_IS_EGG)
         && GetMonAbility(&gPlayerParty[0]) == ABILITY_SYNCHRONIZE)
         {
-            return GetMonData(&gPlayerParty[0], MON_DATA_PERSONALITY) % NUM_NATURES;
+            return GetNature(&gPlayerParty[0], TRUE);
         }
     }
     // random nature


### PR DESCRIPTION
Made it so Synchronize influenced wild encounters take the hidden (nature mint) nature of the lead pokemon into account.

wild_encounters.c (PickWildMonNature())
`GetMonData(&gPlayerParty[0], MON_DATA_PERSONALITY) % NUM_NATURES; -> GetNature(&gPlayerParty[0], TRUE);`